### PR TITLE
Deployments via Infura

### DIFF
--- a/script/common/utils.js
+++ b/script/common/utils.js
@@ -5,6 +5,7 @@
  */
 
 'use strict';
+const {Wallet} = require('ethers');
 const debug = require('debug')('utils');
 
 const unlockByAccount = new Map();
@@ -14,6 +15,10 @@ const unlockTimeInSeconds = typeof process.env.ETH_UNLOCK_SECONDS === 'undefined
 
 exports.isTestNetwork = (network) => {
   return network.includes('develop') || network.includes('test') || network.includes('ganache');
+};
+
+exports.isInfuraNetwork = (network) => {
+  return network.includes('infura');
 };
 
 const getNetworkCredentials = (network) => {
@@ -57,6 +62,8 @@ exports.initializeOwnerAccount = async (web3, network, accounts) => {
   let ownerAccount;
   if (exports.isTestNetwork(network))
     ownerAccount = accounts[0];
+  else if (exports.isInfuraNetwork(network))
+    ownerAccount = Wallet.fromMnemonic(process.env.MNEMONIC).address;
   else {
     const {account, secret} = getNetworkCredentials(network);
     await unlockAccount(web3, account, secret);

--- a/truffle.js
+++ b/truffle.js
@@ -1,47 +1,67 @@
 'use strict';
 
+const HDWalletProvider = require('truffle-hdwallet-provider');
+
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
   networks: {
-    development: {
+    'development': {
       host: 'localhost',
       port: 8545,
       network_id: '*',
       gas: 8000000,
       websockets: true // To take advantage of the confirmations listener and to hear Events using .on or .once
     },
-    develop: {
+    'develop': {
       host: 'localhost',
       port: 9545,
       network_id: '*',
       gas: 8000000,
       websockets: true
     },
-    ganache: {
+    'ganache': {
       host: 'localhost',
       port: 7545,
       network_id: '*',
       gas: 8000000,
       websockets: true
     },
-    ropsten: {
+    'ropsten': {
       host: 'geth-ropsten.ethereum',
       port: 80,
       network_id: '3',
       gas: 8000000,
       skipDryRun: true, // default: false for public nets
-      gasPrice: 40000000000, // default: 20 Gwei
+      gasPrice: process.env.GAS_PRICE ? parseInt(process.env.GAS_PRICE) : 40000000000, // default: 20 Gwei
       timeoutBlocks: 200 // minimum/default: 50
       // confirmations: 2,       // default: 0
     },
-    mainnet: {
+    'ropsten-infura': {
+      provider: () => new HDWalletProvider(process.env.MNEMONIC, process.env.PROVIDER),
+      network_id: '3',
+      gas: 8000000,
+      skipDryRun: true, // default: false for public nets
+      gasPrice: process.env.GAS_PRICE ? parseInt(process.env.GAS_PRICE) : 40000000000, // default: 20 Gwei
+      timeoutBlocks: 200 // minimum/default: 50
+      // confirmations: 2,       // default: 0
+    },
+    'mainnet': {
       host: 'geth-homestead.ethereum',
       port: 80,
       network_id: '1',
       gas: 8000000,
       skipDryRun: true, // default: false for public nets
-      gasPrice: 35000000000, // default: 20 Gwei
+      gasPrice: process.env.GAS_PRICE ? parseInt(process.env.GAS_PRICE) : 35000000000, // default: 20 Gwei
+      timeoutBlocks: 200 // minimum/default: 50
+      // confirmations: 2,       // default: 0
+    },
+    'mainnet-infura': {
+      provider: () => new HDWalletProvider(process.env.MNEMONIC, process.env.PROVIDER),
+      network_id: '1',
+      gas: 8000000,
+      skipDryRun: true, // default: false for public nets
+      gasPrice: process.env.GAS_PRICE ? parseInt(process.env.GAS_PRICE) : 35000000000, // default: 20 Gwei
       timeoutBlocks: 200 // minimum/default: 50
       // confirmations: 2,       // default: 0
     }


### PR DESCRIPTION
This PR adds support to deploy contracts via nodes hosted by Infura or other providers for which [`truffle-hdwallet-provider`](https://github.com/trufflesuite/truffle-hdwallet-provider) may be used. Truffle configurations to target Infura nodes are added for Ropsten and mainnet.